### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,8 @@ jobs:
   build:
     name: Build CodeHarborHub-tutorial
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
Potential fix for [https://github.com/codeharborhub/tutorial/security/code-scanning/3](https://github.com/codeharborhub/tutorial/security/code-scanning/3)

In general, fix this by explicitly specifying the `permissions` for the job or the workflow root so that the `GITHUB_TOKEN` has only the minimal scopes required. Here, the `build` job only needs to read the repository contents (for `actions/checkout`) and upload a Pages artifact; that does not require repo write permissions. The safest minimal change is to add `permissions: contents: read` to the `build` job, mirroring the pattern already used in the `deploy` job.

Concretely, in `.github/workflows/deploy.yml`, under `jobs.build` and alongside `name:` and `runs-on:`, insert a `permissions:` block with `contents: read`. This keeps the `deploy` job’s existing permissions (for Pages and OIDC) unchanged and does not alter any steps. No imports or additional methods are needed because this is purely workflow configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
