### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/issue_creation_workflow.yml
+++ b/.github/workflows/issue_creation_workflow.yml
@@ -1,5 +1,8 @@
 name: Issue Creation Workflow
 
+permissions:
+  contents: read
+
 on:
   issues:
     types: [opened]


### PR DESCRIPTION
Potential fix for [https://github.com/codeharborhub/tutorial/security/code-scanning/4](https://github.com/codeharborhub/tutorial/security/code-scanning/4)

In general, the fix is to explicitly declare a `permissions` block in the workflow or for the specific job so that the `GITHUB_TOKEN` is limited to the minimal rights required. This workflow only needs to read from the repository (and in fact mostly uses public search APIs and event payload data), so `contents: read` is an appropriate minimal starting point.

The best fix with no functional change is to add a top-level `permissions` section (so it applies to all jobs) specifying `contents: read`. This should be added just under the `name:` (or directly under `on:` if preferred), before the `jobs:` key. No changes are necessary to steps or commands, and no additional imports or tools are needed. The rest of the workflow continues to run as before, but with a more restricted token.

Specifically, edit `.github/workflows/issue_creation_workflow.yml` to insert:

```yaml
permissions:
  contents: read
```

after line 2 (the blank line following `name: Issue Creation Workflow`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
