### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr_creation_workflow.yml
+++ b/.github/workflows/pr_creation_workflow.yml
@@ -1,5 +1,9 @@
 name: PR Creation Workflow
 
+permissions:
+  contents: read
+  issues: read
+
 on:
   pull_request:
     types: [opened, edited]


### PR DESCRIPTION
Potential fix for [https://github.com/codeharborhub/tutorial/security/code-scanning/5](https://github.com/codeharborhub/tutorial/security/code-scanning/5)

In general, fix this by explicitly specifying a minimal `permissions:` block in the workflow or job so that the `GITHUB_TOKEN` is restricted to the least privileges required. Since this workflow only appears to read repository metadata and search issues via the GitHub API, read-only scopes for repository contents and issues are sufficient.

The best fix with minimal functional change is to add a `permissions:` block at the workflow root (top level, alongside `name:` and `on:`) so it applies to all jobs that omit their own permissions. For these steps, the token only needs to read repository contents and issues, so we can use:
```yaml
permissions:
  contents: read
  issues: read
```
No existing steps need to be changed; the token will still authenticate successfully for the read-only API calls being made.

Specifically, in `.github/workflows/pr_creation_workflow.yml`, insert the `permissions:` block after the `name: PR Creation Workflow` line and before the `on:` block. No new methods, imports, or other definitions are required, since this is purely a workflow configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
