### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -11,6 +11,8 @@ jobs:
   test-deploy:
     name: Test deployment
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
Potential fix for [https://github.com/codeharborhub/tutorial/security/code-scanning/6](https://github.com/codeharborhub/tutorial/security/code-scanning/6)

In general, the fix is to explicitly declare `permissions` for the workflow or specific jobs so that the `GITHUB_TOKEN` has only the scopes needed. For this workflow, the job only checks out code and runs Node-based install/build steps, so it only needs read access to repository contents.

The best minimal fix without changing behavior is to add a `permissions` block setting `contents: read`. This can be added either at the workflow root (applies to all jobs) or within the `test-deploy` job. Since there is only one job in the provided snippet, we can add it at the job level to directly address the CodeQL warning at that job. Concretely, in `.github/workflows/test-deploy.yml`, insert:

```yaml
    permissions:
      contents: read
```

between the `runs-on: ubuntu-latest` line and the `steps:` line inside the `test-deploy` job. No imports or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
