### PR TITLE
Potential fix for code scanning alert no. 1: Code injection

### DIFF
--- a/.github/workflows/issue_creation_workflow.yml
+++ b/.github/workflows/issue_creation_workflow.yml
@@ -33,16 +33,20 @@ jobs:
 
       - name: Validate Issue Content
         id: validate-issue
+        env:
+          ISSUE_BODY: ${{ github.event.issue.body }}
         run: |
-          issue_body="${{ github.event.issue.body }}"
+          issue_body="$ISSUE_BODY"
           if [[ "$issue_body" == *"AI-generated content"* ]] || [[ "$issue_body" == *"existing sites"* ]]; then
             echo "Issue body contains disallowed content."
             exit 1
           fi
 
       - name: Check for Security and Trust
+        env:
+          ISSUE_BODY: ${{ github.event.issue.body }}
         run: |
-          issue_body="${{ github.event.issue.body }}"
+          issue_body="$ISSUE_BODY"
           if [[ "$issue_body" != *"security"* ]] || [[ "$issue_body" != *"trust"* ]]; then
             echo "Issue does not mention security or trust."
             exit 1


### PR DESCRIPTION
Potential fix for [https://github.com/codeharborhub/tutorial/security/code-scanning/1](https://github.com/codeharborhub/tutorial/security/code-scanning/1)

To fix the problem, we should stop inserting `github.event.issue.body` directly into the shell script via GitHub expression syntax and instead pass it through an environment variable, then read that environment variable using normal shell variable expansion. This removes the opportunity for the GitHub expression engine to splice attacker-controlled text directly into the script’s source.

The best minimal-change fix is:
- Add an `env:` section to the `Validate Issue Content` and `Check for Security and Trust` steps to map `ISSUE_BODY: ${{ github.event.issue.body }}`.
- In each `run:` block, replace `issue_body="${{ github.event.issue.body }}"` with `issue_body="$ISSUE_BODY"`.

This preserves all existing logic (string checks on the issue body) while aligning with GitHub’s recommended safe pattern. No additional methods or external libraries are needed; only YAML changes within `.github/workflows/issue_creation_workflow.yml` in the two affected steps.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
