### PR TITLE
Potential fix for code scanning alert no. 2: Code injection

### DIFF
--- a/.github/workflows/issue_creation_workflow.yml
+++ b/.github/workflows/issue_creation_workflow.yml
@@ -41,9 +41,10 @@ jobs:
           fi
 
       - name: Check for Security and Trust
+        env:
+          ISSUE_BODY: ${{ github.event.issue.body }}
         run: |
-          issue_body="${{ github.event.issue.body }}"
+          issue_body="$ISSUE_BODY"
           if [[ "$issue_body" != *"security"* ]] || [[ "$issue_body" != *"trust"* ]]; then
             echo "Issue does not mention security or trust."
             exit 1
-          fi


### PR DESCRIPTION
Potential fix for [https://github.com/codeharborhub/tutorial/security/code-scanning/2](https://github.com/codeharborhub/tutorial/security/code-scanning/2)

To fix the problem, we should stop interpolating the untrusted `github.event.issue.body` directly into the shell script and instead pass it via an environment variable, then read it using native shell syntax (`$ISSUE_BODY`). This avoids GitHub Actions expression injection in the shell context while preserving existing behavior.

Concretely, in the `Check for Security and Trust` step (lines 43–49), we will:

- Add an `env:` section that sets `ISSUE_BODY: ${{ github.event.issue.body }}`.
- Change the script to use `issue_body="$ISSUE_BODY"` (or just use `$ISSUE_BODY` directly) instead of `issue_body="${{ github.event.issue.body }}"`.

We will leave the logic of the checks unchanged. No additional imports or external tools are needed, and no other steps in the file are modified.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
